### PR TITLE
Add mock/fake templates

### DIFF
--- a/blaze-test-helpers.js
+++ b/blaze-test-helpers.js
@@ -2,6 +2,7 @@ import { _ } from 'meteor/underscore';
 import { Template } from 'meteor/templating';
 import { Blaze } from 'meteor/blaze';
 import { Tracker } from 'meteor/tracker';
+import { mockTemplate, restoreTemplate } from './mock-templates.js';
 
 const withDiv = function withDiv(callback) {
   const el = document.createElement('div');
@@ -20,4 +21,9 @@ export const withRenderedTemplate = function withRenderedTemplate(template, data
     Tracker.flush();
     callback(el);
   });
+};
+
+export {
+  mockTemplate,
+  restoreTemplate
 };

--- a/mock-templates.js
+++ b/mock-templates.js
@@ -1,0 +1,30 @@
+import { Template } from 'meteor/templating';
+import { Blaze } from 'meteor/blaze';
+
+const originalTemplates = {};
+function mockTemplate(templateName) {
+  if (!originalTemplates[templateName]) {
+    originalTemplates[templateName] = Template[templateName];
+    // Mock the template with a Blaze template doing nothing
+    Template[templateName] = new Blaze.Template(templateName, () => {});
+  } else {
+    throw new Error(`
+      Template ${templateName} was already mocked.
+      Please restore it before
+    `);
+  }
+  
+}
+
+function restoreTemplate(templateName) {
+  if (originalTemplates[templateName]) {
+    Template[templateName] = originalTemplates[templateName];
+    originalTemplates[templateName] = undefined;
+  }
+  
+}
+
+export {
+  mockTemplate,
+  restoreTemplate
+}


### PR DESCRIPTION
Add functions to mock/fake templates.
Sometimes you want to to test a parent template without testing the child one. With this functions you can fake it from your tests.